### PR TITLE
Add support for Ubuntu where fd_set.__fds_bits is only 16 bits

### DIFF
--- a/Sources/dns_sd/FD.swift
+++ b/Sources/dns_sd/FD.swift
@@ -17,7 +17,11 @@ internal enum FD {
     /// - Returns: The set that is opinted at is filled with all zero's.
     ///
     internal static func zero(_ set: inout fd_set) {
+        #if arch(arm) // 32 bits
         set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        #else // 16 bits
+        set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        #endif
     }
 
     /// Replacement for FD_SET macro.
@@ -30,8 +34,14 @@ internal enum FD {
     /// - Note: If you receive an EXC_BAD_INSTRUCTION at the mask statement, then most likely the socket was already closed.
     ///
     internal static func set(_ fd: Int32, set: inout fd_set) {
+        // see https://github.com/Kitura/BlueSocket/issues/10
+        #if arch(arm) // 32 bits
         let intOffset = Int(fd / 32)
         let bitOffset = Int(fd % 32)
+        #else // 16 bits
+        let intOffset = Int(fd / 16)
+        let bitOffset = Int(fd % 16)
+        #endif
         let mask = Int(1 << bitOffset)
         switch intOffset {
             case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
@@ -50,6 +60,7 @@ internal enum FD {
             case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
             case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
             case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
+            #if arch(arm) // 32 bits
             case 16: set.__fds_bits.16 = set.__fds_bits.16 | mask
             case 17: set.__fds_bits.17 = set.__fds_bits.17 | mask
             case 18: set.__fds_bits.18 = set.__fds_bits.18 | mask
@@ -66,6 +77,7 @@ internal enum FD {
             case 29: set.__fds_bits.29 = set.__fds_bits.29 | mask
             case 30: set.__fds_bits.30 = set.__fds_bits.30 | mask
             case 31: set.__fds_bits.31 = set.__fds_bits.31 | mask
+            #endif
             default: break
         }
     }
@@ -78,8 +90,14 @@ internal enum FD {
     /// - Returns: The given set is updated in place, with the bit at offset 'fd' cleared to 0.
     ///
     internal static func clr(_ fd: Int32, set: inout fd_set) {
+        // see https://github.com/Kitura/BlueSocket/issues/10
+        #if arch(arm) // 32 bits
         let intOffset = Int(fd / 32)
         let bitOffset = Int(fd % 32)
+        #else // 16 bits
+        let intOffset = Int(fd / 16)
+        let bitOffset = Int(fd % 16)
+        #endif
         let mask = Int(~(1 << bitOffset))
         switch intOffset {
             case 0: set.__fds_bits.0 = set.__fds_bits.0 & mask
@@ -98,6 +116,7 @@ internal enum FD {
             case 13: set.__fds_bits.13 = set.__fds_bits.13 & mask
             case 14: set.__fds_bits.14 = set.__fds_bits.14 & mask
             case 15: set.__fds_bits.15 = set.__fds_bits.15 & mask
+            #if arch(arm) // 32 bits
             case 16: set.__fds_bits.16 = set.__fds_bits.16 & mask
             case 17: set.__fds_bits.17 = set.__fds_bits.17 & mask
             case 18: set.__fds_bits.18 = set.__fds_bits.18 & mask
@@ -114,6 +133,7 @@ internal enum FD {
             case 29: set.__fds_bits.29 = set.__fds_bits.29 & mask
             case 30: set.__fds_bits.30 = set.__fds_bits.30 & mask
             case 31: set.__fds_bits.31 = set.__fds_bits.31 & mask
+            #endif
             default: break
         }
     }
@@ -126,8 +146,14 @@ internal enum FD {
     /// - Returns: 'true' if the bit at offset 'fd' is 1, 'false' otherwise.
     ///
     internal static func isSet(_ fd: Int32, set: inout fd_set) -> Bool {
+        // see https://github.com/Kitura/BlueSocket/issues/10
+        #if arch(arm) // 32 bits
         let intOffset = Int(fd / 32)
         let bitOffset = Int(fd % 32)
+        #else // 16 bits
+        let intOffset = Int(fd / 16)
+        let bitOffset = Int(fd % 16)
+        #endif
         let mask = Int(1 << bitOffset)
         switch intOffset {
             case 0: return set.__fds_bits.0 & mask != 0
@@ -146,6 +172,7 @@ internal enum FD {
             case 13: return set.__fds_bits.13 & mask != 0
             case 14: return set.__fds_bits.14 & mask != 0
             case 15: return set.__fds_bits.15 & mask != 0
+            #if arch(arm) // 32 bits
             case 16: return set.__fds_bits.16 & mask != 0
             case 17: return set.__fds_bits.17 & mask != 0
             case 18: return set.__fds_bits.18 & mask != 0
@@ -162,6 +189,7 @@ internal enum FD {
             case 29: return set.__fds_bits.29 & mask != 0
             case 30: return set.__fds_bits.30 & mask != 0
             case 31: return set.__fds_bits.31 & mask != 0
+            #endif
             default: return false
         }
     }
@@ -188,8 +216,14 @@ internal enum FD {
     /// - Note: If you receive an EXC_BAD_INSTRUCTION at the mask statement, then most likely the socket was already closed.
     ///
     internal static func set(_ fd: Int32, set: inout fd_set) {
+        // see https://github.com/Kitura/BlueSocket/issues/10
+        #if arch(arm) // 32 bits
         let intOffset = Int32(fd / 32)
         let bitOffset = Int32(fd % 32)
+        #else // 16 bits
+        let intOffset = Int(fd / 16)
+        let bitOffset = Int(fd % 16)
+        #endif
         let mask = Int32(1 << bitOffset)
         switch intOffset {
             case 0: set.fds_bits.0 = set.fds_bits.0 | mask
@@ -208,6 +242,7 @@ internal enum FD {
             case 13: set.fds_bits.13 = set.fds_bits.13 | mask
             case 14: set.fds_bits.14 = set.fds_bits.14 | mask
             case 15: set.fds_bits.15 = set.fds_bits.15 | mask
+            #if arch(arm) // 32 bits
             case 16: set.fds_bits.16 = set.fds_bits.16 | mask
             case 17: set.fds_bits.17 = set.fds_bits.17 | mask
             case 18: set.fds_bits.18 = set.fds_bits.18 | mask
@@ -224,6 +259,7 @@ internal enum FD {
             case 29: set.fds_bits.29 = set.fds_bits.29 | mask
             case 30: set.fds_bits.30 = set.fds_bits.30 | mask
             case 31: set.fds_bits.31 = set.fds_bits.31 | mask
+            #endif
             default: break
         }
     }
@@ -236,8 +272,14 @@ internal enum FD {
     /// - Returns: The given set is updated in place, with the bit at offset 'fd' cleared to 0.
     ///
     internal static func clr(_ fd: Int32, set: inout fd_set) {
+        // see https://github.com/Kitura/BlueSocket/issues/10
+        #if arch(arm) // 32 bits
         let intOffset = Int32(fd / 32)
         let bitOffset = Int32(fd % 32)
+        #else // 16 bits
+        let intOffset = Int(fd / 16)
+        let bitOffset = Int(fd % 16)
+        #endif
         let mask = Int32(~(1 << bitOffset))
         switch intOffset {
             case 0: set.fds_bits.0 = set.fds_bits.0 & mask
@@ -256,6 +298,7 @@ internal enum FD {
             case 13: set.fds_bits.13 = set.fds_bits.13 & mask
             case 14: set.fds_bits.14 = set.fds_bits.14 & mask
             case 15: set.fds_bits.15 = set.fds_bits.15 & mask
+            #if arch(arm) // 32 bits
             case 16: set.fds_bits.16 = set.fds_bits.16 & mask
             case 17: set.fds_bits.17 = set.fds_bits.17 & mask
             case 18: set.fds_bits.18 = set.fds_bits.18 & mask
@@ -272,6 +315,7 @@ internal enum FD {
             case 29: set.fds_bits.29 = set.fds_bits.29 & mask
             case 30: set.fds_bits.30 = set.fds_bits.30 & mask
             case 31: set.fds_bits.31 = set.fds_bits.31 & mask
+            #endif
             default: break
         }
     }
@@ -284,8 +328,14 @@ internal enum FD {
     /// - Returns: 'true' if the bit at offset 'fd' is 1, 'false' otherwise.
     ///
     internal static func isSet(_ fd: Int32, set: inout fd_set) -> Bool {
+        // see https://github.com/Kitura/BlueSocket/issues/10
+        #if arch(arm) // 32 bits
         let intOffset = Int32(fd / 32)
         let bitOffset = Int32(fd % 32)
+        #else // 16 bits
+        let intOffset = Int(fd / 16)
+        let bitOffset = Int(fd % 16)
+        #endif
         let mask = Int32(1 << bitOffset)
         switch intOffset {
             case 0: return set.fds_bits.0 & mask != 0
@@ -304,6 +354,7 @@ internal enum FD {
             case 13: return set.fds_bits.13 & mask != 0
             case 14: return set.fds_bits.14 & mask != 0
             case 15: return set.fds_bits.15 & mask != 0
+            #if arch(arm) // 32 bits
             case 16: return set.fds_bits.16 & mask != 0
             case 17: return set.fds_bits.17 & mask != 0
             case 18: return set.fds_bits.18 & mask != 0
@@ -320,6 +371,7 @@ internal enum FD {
             case 29: return set.fds_bits.29 & mask != 0
             case 30: return set.fds_bits.30 & mask != 0
             case 31: return set.fds_bits.31 & mask != 0
+            #endif
             default: return false
         }
     }


### PR DESCRIPTION
Trying to build in Ubuntu, i.e. in the official swift docker image, results in the following errors
```
/code/.build/checkouts/dns_sd/Sources/dns_sd/FD.swift:20:26: error: cannot assign value of type '(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)' to type '(__fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask, __fd_mask)' (aka '(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)')
        set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
See similar issue and solution in https://github.com/Kitura/BlueSocket/issues/10
